### PR TITLE
Startup mechanism changed for GCC_ARM

### DIFF
--- a/targets/TARGET_ublox/TARGET_R5030/device/TOOLCHAIN_GCC_ARM/r5030.ld
+++ b/targets/TARGET_ublox/TARGET_R5030/device/TOOLCHAIN_GCC_ARM/r5030.ld
@@ -2,7 +2,8 @@
 MEMORY
 { 
   FLASH (rx) : ORIGIN = 0x00000000, LENGTH = 64K
-  RAM (rwx)  : ORIGIN = 0x20000000 + 0xF8, LENGTH = 64K - 0xF8
+  RAM (rwx)  : ORIGIN = 0x20000000 + 0xF8, LENGTH = 64K - 0xF8 
+  PSRAM (rwx): ORIGIN = 0x60000000, LENGTH = 128K
 }
 
 /* Linker script to place sections and symbol values. Should be used together
@@ -132,7 +133,7 @@ SECTIONS
         __HeapBase = .;
         *(.heap*)
         __HeapLimit = .;
-    } > RAM
+    } > PSRAM
 
     /* .stack_dummy section doesn't contains any symbols. It is only
      * used for linker to calculate size of stack sections, and assign
@@ -140,8 +141,8 @@ SECTIONS
     .stack_dummy (COPY):
     {
         *(.stack*)
-    } > RAM
-
+    } > PSRAM
+    
     /* Set stack top to end of RAM, and stack limit move down by
      * size of stack_dummy section */
     __StackTop = ORIGIN(RAM) + LENGTH(RAM);
@@ -150,5 +151,5 @@ SECTIONS
     PROVIDE(__stack = __StackTop);
 
     /* Check if data + heap + stack exceeds RAM limit */
-    ASSERT(__StackLimit >= __HeapLimit, "region RAM overflowed with stack")
+    /*ASSERT(__StackLimit >= __HeapLimit, "region RAM overflowed with stack")*/
 }

--- a/targets/TARGET_ublox/TARGET_R5030/device/TOOLCHAIN_GCC_ARM/startup_KM_app.S
+++ b/targets/TARGET_ublox/TARGET_R5030/device/TOOLCHAIN_GCC_ARM/startup_KM_app.S
@@ -200,20 +200,20 @@ Reset_Handler:
  *
  *  All addresses must be aligned to 4 bytes boundary.
  */
-    ldr    r1, =__etext
-    ldr    r2, =__data_start__
-    ldr    r3, =__data_end__
-
-    subs    r3, r2
-    ble    .L_loop1_done
-
-.L_loop1:
-    subs    r3, #4
-    ldr    r0, [r1,r3]
-    str    r0, [r2,r3]
-    bgt    .L_loop1
-
-.L_loop1_done:
+@    ldr    r1, =__etext
+@    ldr    r2, =__data_start__
+@    ldr    r3, =__data_end__
+@
+@    subs    r3, r2
+@    ble    .L_loop1_done
+@
+@.L_loop1:
+@    subs    r3, #4
+@    ldr    r0, [r1,r3]
+@    str    r0, [r2,r3]
+@    bgt    .L_loop1
+@
+@.L_loop1_done:
 #endif /*__STARTUP_COPY_MULTIPLE */
 
 /*  This part of work usually is done in C library startup code. Otherwise,
@@ -263,19 +263,19 @@ Reset_Handler:
  *
  *  Both addresses must be aligned to 4 bytes boundary.
  */
-    ldr    r1, =__bss_start__
-    ldr    r2, =__bss_end__
-
-    movs    r0, 0
-
-    subs    r2, r1
-    ble    .L_loop3_done
-
-.L_loop3:
-    subs    r2, #4
-    str    r0, [r1, r2]
-    bgt    .L_loop3
-.L_loop3_done:
+@    ldr    r1, =__bss_start__
+@    ldr    r2, =__bss_end__
+@
+@    movs    r0, 0
+@
+@    subs    r2, r1
+@    ble    .L_loop3_done
+@
+@.L_loop3:
+@    subs    r2, #4
+@    str    r0, [r1, r2]
+@    bgt    .L_loop3
+@.L_loop3_done:
 #endif /* __STARTUP_CLEAR_BSS_MULTIPLE || __STARTUP_CLEAR_BSS */
 
 #ifndef __NO_SYSTEM_INIT

--- a/targets/TARGET_ublox/TARGET_R5030/device/ps_ram.c
+++ b/targets/TARGET_ublox/TARGET_R5030/device/ps_ram.c
@@ -1,0 +1,113 @@
+/**************************************************************************//**
+ * @file     ps_ram.c
+ * @brief    PS RAM Source File for Device KM
+ * @version  V01
+ * @date     15 March 2018
+ *
+ * @note
+ *
+ ******************************************************************************/
+#include "KM_app.h"
+
+/** Macro generating the mask for a bitfield of \p n bits */
+#define DRIVER_BIT_SET(n)                      (1u<<(n))
+
+#define DRIVER_BITS_CLR(data, mask)            ((data) & ~(mask))
+#define DRIVER_BITS_SET(data, bits)            ((data) |  (bits))
+
+/** Macro generating the mask for a bitfield of \p n bits */
+#define DRIVER_BIT_MASK(n)                      (DRIVER_BIT_SET(n) - 1)
+
+/** Macro generating the mask for a bitfield defined as `name_OFFSET` and `name_SIZE` */
+#define DRIVER_BITFIELD_MASK_(name)             (DRIVER_BIT_MASK(name##_SIZE) << (name##_OFFSET))
+#define DRIVER_BITFIELD_MASK(name)              DRIVER_BITFIELD_MASK_(name)
+
+/** Extract bitfield defined as `name_OFFSET` and `name_SIZE` from \p data */
+#define DRIVER_BITFIELD_GET_(data, name)        (((data) >> name##_OFFSET) & DRIVER_BIT_MASK(name##_SIZE))
+#define DRIVER_BITFIELD_GET(data, name)         DRIVER_BITFIELD_GET_(data, name)
+
+/** Return \p data with bitfield defined as `name_OFFSET` and `name_SIZE` cleared */
+#define DRIVER_BITFIELD_CLR(data, name)         ((data) & ~DRIVER_BITFIELD_MASK(name))
+
+/** Return \p bitfield defined as `name_OFFSET` and `name_SIZE` set to \p value */
+#define DRIVER_BITFIELD_VAL_(name, value)       (((value) & DRIVER_BIT_MASK(name##_SIZE)) << name##_OFFSET)
+#define DRIVER_BITFIELD_VAL(name, value)        DRIVER_BITFIELD_VAL_(name, value)
+
+/** Return \p data with bitfield defined as `name_OFFSET` and `name_SIZE` set to \p value */
+#define DRIVER_BITFIELD_SET(data, name, value)  (DRIVER_BITFIELD_CLR(data, name) | DRIVER_BITFIELD_VAL(name, value))
+
+/** Return \p bitfield defined as `name_OFFSET` and `name_SIZE` set to \p name_ENUM_value */
+#define DRIVER_BITFIELD_ENUM_(name, enumValue)      DRIVER_BITFIELD_VAL(name, name##_ENUM_##enumValue)
+#define DRIVER_BITFIELD_ENUM(name, enumValue)       DRIVER_BITFIELD_ENUM_(name, enumValue)
+
+/** Return \p data with bitfield defined as `name_OFFSET` and `name_SIZE` set to \p name_ENUM_value */
+#define DRIVER_BITFIELD_SET_ENUM(data, name, enumValue)  DRIVER_BITFIELD_SET(data, name,  DRIVER_BITFIELD_ENUM(name, enumValue))
+
+/**
+ * PS RAM Configurations
+ * Disable AXI Bus
+ * Configure
+ * Enable AXI Bus
+ */
+
+void PsRamSettings(void)
+{
+      // Disable AXI
+      app_ss_psram_ctrl->axi_ctrl = 0x00000000;
+
+#ifdef PSRAM_ASYNC_MODE_ENABLED
+
+      // Set async mode read and write latencies
+      app_ss_psram_ctrl->async_mode_latency = (DRIVER_BITFIELD_VAL(PSRAM_ASYNC_MODE_LATENCY_ASYNC_MODE_READ_LATENCY,  0x4) |
+                                               DRIVER_BITFIELD_VAL(PSRAM_ASYNC_MODE_LATENCY_ASYNC_MODE_WRITE_LATENCY, 0x3) ); // 0x00000403
+
+      // Set address width
+      app_ss_psram_ctrl->psram_addr_width = ((1 << 24) - 1); //0x00FFFFFF
+
+#else // Assume DDR mode enabled
+
+      // Set sync latency + wait type
+      app_ss_psram_ctrl->sync_mode_latency =(DRIVER_BITFIELD_VAL(PSRAM_SYNC_MODE_LATENCY_SYNC_MODE_READ_LATENCY,  0x2) |
+                                             DRIVER_BITFIELD_VAL(PSRAM_SYNC_MODE_LATENCY_SYNC_MODE_WRITE_LATENCY, 0x2) ); //0x00000022
+
+      // Set address width
+      app_ss_psram_ctrl->psram_addr_width = ((1 << 24) - 1); //0x00FFFFFF
+
+      // Set PHY CFG, AP memory DDR index in BCR
+      app_ss_psram_ctrl->psram_controller_phy_cfg = (DRIVER_BITFIELD_VAL(PSRAM_PSRAM_CONTROLLER_PHY_CFG_PSRAM_CONTROLLER_PHY_DQS_SWITCH_ENABLE, 0x1) |
+                                                     DRIVER_BITFIELD_VAL(PSRAM_PSRAM_CONTROLLER_PHY_CFG_PSRAM_CONTROLLER_PHY_BCR_DDR_INDEX,     0x9) |
+                                                     DRIVER_BITFIELD_VAL(PSRAM_PSRAM_CONTROLLER_PHY_CFG_PSRAM_CONTROLLER_PHY_RX_WAIT_FEEDBACK,  0x1) |
+                                                     DRIVER_BITFIELD_VAL(PSRAM_PSRAM_CONTROLLER_PHY_CFG_PSRAM_CONTROLLER_PHY_RX_TIMEOUT,        0xA) |
+                                                     DRIVER_BITFIELD_VAL(PSRAM_PSRAM_CONTROLLER_PHY_CFG_PSRAM_CONTROLLER_PHY_RX_TIMEOUT_ENABLE, 0x1) ); //0x00005598
+
+      // Set PHY read data capture DQs
+      app_ss_psram_ctrl->phy_read_data_capture = 0x00000001;
+
+      //Enable BCR write request
+      app_ss_psram_ctrl->bcr = (DRIVER_BITFIELD_VAL(PSRAM_BCR_BURST_LENGTH,           0x7) |
+                                DRIVER_BITFIELD_VAL(PSRAM_BCR_BURST_WRAP,             0x1) |
+                                DRIVER_BITFIELD_VAL(PSRAM_BCR_DRIVE_STRENGTH,         0x1) |
+                                DRIVER_BITFIELD_VAL(PSRAM_BCR_WAIT_CONFIGURATION,     0x1) |
+                                DRIVER_BITFIELD_VAL(PSRAM_BCR_SDR_DDR_MODE_AP_MEMORY, 0x1) |
+                                DRIVER_BITFIELD_VAL(PSRAM_BCR_WAIT_POLARITY,          0x1) |
+                                DRIVER_BITFIELD_VAL(PSRAM_BCR_LATENCY_COUNTER,        0x2) |
+                                DRIVER_BITFIELD_VAL(PSRAM_BCR_INITIAL_LATENCY,        0x1) ); //0x0000571F;
+
+      app_ss_psram_ctrl->bcr_write_req = 0x1;
+
+      while(((app_ss_psram_ctrl->bcr_write_req) & 0x1) == 0x1)
+      {
+        asm volatile("NOP");
+      }
+
+      if(((app_ss_psram_ctrl->psram_irq_and_fault_status_raw) & 0x1) == 0x1)
+      {
+        app_ss_psram_ctrl->psram_irq_and_fault_status_clr = 0x1;
+      }
+
+#endif // #ifdef PSRAM_ASYNC_MODE_ENABLED
+
+      // Re-enable AXI
+      app_ss_psram_ctrl->axi_ctrl = 0x00000001; //(1 << PSRAM_AXI_CTRL_AXI_ENABLE_OFFSET)
+}
+

--- a/targets/TARGET_ublox/TARGET_R5030/device/ps_ram.h
+++ b/targets/TARGET_ublox/TARGET_R5030/device/ps_ram.h
@@ -1,0 +1,36 @@
+/**************************************************************************//**
+ * @file     ps_ram.h
+ * @brief    PS RAM configurations device KM
+ * @version  V01
+ * @date     15 March 2018
+ *
+ * @note
+ *
+ ******************************************************************************/
+
+#ifndef PS_RAM_H
+#define PS_RAM_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+//#include <stdint.h>
+
+/**
+ * Configure and Initialize PS RAM
+ *
+ * @param  none
+ * @return none
+ *
+ * @brief  Necessary to be intialized
+ * before systemInit() function in system_KM_app
+ */
+
+extern void PsRamSettings(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PS_RAM_H */

--- a/targets/TARGET_ublox/mbed_rtx.h
+++ b/targets/TARGET_ublox/mbed_rtx.h
@@ -25,7 +25,7 @@
 
 #if defined(TARGET_R5030)
 #ifndef INITIAL_SP
-#define INITIAL_SP              (0x20000000 + 0x10000)
+#define INITIAL_SP              (0x60000000 + 20000) //(0x20000000 + 0x10000)
 
 #endif
 #else


### PR DESCRIPTION
## Description

Startup mechanism changed for GCC_ARM as it is not suitable for  @DS-5
PS RAM configurations also introduced but need to be checked on FPGA if these are working and/or required
