### PR TITLE
Adding IAr linker script and startup file

### DIFF
--- a/targets/TARGET_ublox/TARGET_R5030/device/TOOLCHAIN_IAR/r5030.icf
+++ b/targets/TARGET_ublox/TARGET_R5030/device/TOOLCHAIN_IAR/r5030.icf
@@ -48,8 +48,8 @@ initialize by copy { readwrite };
 initialize by copy { section .intvec };
 do not initialize  { section .noinit };
 
-/* place at address mem:__region_INTVEC_FLASH_start__  { section .intvec }; */
-place in VEC_region    { section .intvec }; 
+//place at address mem:__region_INTVEC_FLASH_start__  { section .intvec }; /* */
+place in VEC_region  { section .intvec }; 
 place in FLASH_region  { readonly };
 place in DATA_region   { block RW };
 place in DATA_region   { block ZI };

--- a/targets/TARGET_ublox/TARGET_R5030/device/TOOLCHAIN_IAR/r5030.icf
+++ b/targets/TARGET_ublox/TARGET_R5030/device/TOOLCHAIN_IAR/r5030.icf
@@ -48,8 +48,8 @@ initialize by copy { readwrite };
 initialize by copy { section .intvec };
 do not initialize  { section .noinit };
 
-place at address mem:__region_INTVEC_FLASH_start__  { section .intvec }; /* */
-//place in VEC_region    { section .intvec }; 
+/* place at address mem:__region_INTVEC_FLASH_start__  { section .intvec }; */
+place in VEC_region    { section .intvec }; 
 place in FLASH_region  { readonly };
 place in DATA_region   { block RW };
 place in DATA_region   { block ZI };

--- a/targets/TARGET_ublox/TARGET_R5030/device/TOOLCHAIN_IAR/r5030.icf
+++ b/targets/TARGET_ublox/TARGET_R5030/device/TOOLCHAIN_IAR/r5030.icf
@@ -1,0 +1,57 @@
+/* Sizes and locations */
+
+define symbol __start_flash__       = 0x00000000;
+define symbol __size_flash__        = 0x10000;			//64K
+define symbol __start_ram__         = 0x20000000;
+define symbol __size_ram__          = 0x10000;
+define symbol __size_flash_vtable__ = 0xF8;
+define symbol __size_ram_vtable__   = 0xF8;  /* (B8=184)Reserve space for dynamic vectors mapped to RAM (see cmsis_nvic.c) */
+
+if (isdefinedsymbol(__stack_size__)) {
+  define symbol __size_cstack__        = __stack_size__;
+} else {
+  define symbol __size_cstack__        = 1024;
+}
+
+if (isdefinedsymbol(__heap_size__)) {
+  define symbol __size_heap__          = __heap_size__;
+} else {
+  define symbol __size_heap__          = (256);
+}
+
+/* Memory regions */
+
+define symbol __region_INTVEC_FLASH_start__ = __start_flash__;
+define symbol __region_INTVEC_FLASH_end__   = __start_flash__ + __size_flash_vtable__ - 1;
+define symbol __region_TEXT_start__         = __start_flash__ + __size_flash_vtable__; /* Leave room for flash vector table at start */
+define symbol __region_TEXT_end__           = __start_flash__ + __size_flash__ - 1;
+define symbol __region_INTVEC_RAM_start__   = __start_ram__;
+define symbol __region_DATA_start__         = __start_ram__ + __size_ram_vtable__; /* Leave room for RAM vector table at start */
+define symbol __region_DATA_end__           = __start_ram__ + __size_ram__ - __size_cstack__ - 1; /* Leave room for stack at end */
+define symbol __region_CSTACK_start__       = __start_ram__ + __size_ram__ - __size_cstack__;
+define symbol __region_CSTACK_end__         = __start_ram__ + __size_ram__ - 1;
+
+define memory mem with size = 4G;
+define region VEC_region     = mem:[from __region_INTVEC_FLASH_start__ to __region_INTVEC_FLASH_end__];
+define region FLASH_region   = mem:[from __region_TEXT_start__ to __region_TEXT_end__];
+define region DATA_region    = mem:[from __region_DATA_start__ to __region_DATA_end__];
+define region CSTACK_region  = mem:[from __region_CSTACK_start__ to __region_CSTACK_end__];
+
+define block CSTACK     with alignment = 8, size = __size_cstack__     { };
+define block HEAP       with alignment = 8, size = __size_heap__       { };
+define block RW         { readwrite };
+define block ZI         { zi };
+
+/* Place sections */
+
+initialize by copy { readwrite };
+initialize by copy { section .intvec };
+do not initialize  { section .noinit };
+
+place at address mem:__region_INTVEC_FLASH_start__  { section .intvec }; /* */
+//place in VEC_region    { section .intvec }; 
+place in FLASH_region  { readonly };
+place in DATA_region   { block RW };
+place in DATA_region   { block ZI };
+place in DATA_region   { last block HEAP };
+place in CSTACK_region { block CSTACK };

--- a/targets/TARGET_ublox/TARGET_R5030/device/TOOLCHAIN_IAR/startup_KM_app.S
+++ b/targets/TARGET_ublox/TARGET_R5030/device/TOOLCHAIN_IAR/startup_KM_app.S
@@ -43,7 +43,7 @@
         ; Stack size default : 1024
         ; Heap size default : 2048
         ; Forward declaration of sections.
-        ;SECTION CSTACK:DATA:NOROOT(3)
+        SECTION CSTACK:DATA:NOROOT(3)
 
         SECTION .intvec:CODE:NOROOT(4)
         EXTERN  __iar_program_start
@@ -55,13 +55,13 @@
 
         DATA
 __Vectors
-        DCD     0x20010000
+        DCD     sfe(CSTACK)
         DCD     Reset_Handler
         DCD     NMI_Handler
         DCD     HardFault_Handler
-        DCD     0
-        DCD     0
-        DCD     0
+        DCD     MemManage_Handler
+        DCD     BusFault_Handler
+        DCD     UsageFault_Handler
         DCD     0
         DCD     0
         DCD     0
@@ -143,6 +143,18 @@ NMI_Handler
         PUBWEAK HardFault_Handler
         SECTION .text:CODE:NOROOT(1)
 HardFault_Handler
+        B .
+        PUBWEAK MemManage_Handler
+        SECTION .text:CODE:NOROOT(1)
+MemManage_Handler
+        B .
+        PUBWEAK BusFault_Handler
+        SECTION .text:CODE:NOROOT(1)
+BusFault_Handler
+        B .
+        PUBWEAK UsageFault_Handler
+        SECTION .text:CODE:NOROOT(1)
+UsageFault_Handler
         B .
         PUBWEAK SVC_Handler
         SECTION .text:CODE:NOROOT(1)

--- a/targets/TARGET_ublox/TARGET_R5030/device/TOOLCHAIN_IAR/startup_KM_app.S
+++ b/targets/TARGET_ublox/TARGET_R5030/device/TOOLCHAIN_IAR/startup_KM_app.S
@@ -1,0 +1,349 @@
+;/**************************************************************************//**
+; * @file     startup_KM_app.s
+; * @brief    CMSIS Cortex-M7 Core Device Startup File for
+; *           Device KM
+; * @version  V5.00
+; * @date     07. March 2016
+; ******************************************************************************/
+;/*
+; * Copyright (c) 2009-2016 ARM Limited. All rights reserved.
+; *
+; * SPDX-License-Identifier: Apache-2.0
+; *
+; * Licensed under the Apache License, Version 2.0 (the License); you may
+; * not use this file except in compliance with the License.
+; * You may obtain a copy of the License at
+; *
+; * www.apache.org/licenses/LICENSE-2.0
+; *
+; * Unless required by applicable law or agreed to in writing, software
+; * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+; * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+; * See the License for the specific language governing permissions and
+; * limitations under the License.
+; */
+
+
+;
+; The modules in this file are included in the libraries, and may be replaced
+; by any user-defined modules that define the PUBLIC symbol _program_start or
+; a user defined start symbol.
+; To override the cstartup defined in the library, simply add your modified
+; version to the workbench project.
+;
+; The vector table is normally located at address 0.
+; When debugging in RAM, it can be located in RAM, aligned to at least 2^6.
+; The name "__vector_table" has special meaning for C-SPY:
+; it is where the SP start value is found, and the NVIC vector
+; table register (VTOR) is initialized to this address if != 0.
+;
+; Cortex-M version
+;
+        MODULE  ?cstartup
+        ; Stack size default : 1024
+        ; Heap size default : 2048
+        ; Forward declaration of sections.
+        ;SECTION CSTACK:DATA:NOROOT(3)
+
+        SECTION .intvec:CODE:NOROOT(4)
+        EXTERN  __iar_program_start
+        EXTERN  SystemInit
+        ;PUBLIC  __vector_table
+        PUBLIC  __Vectors
+        PUBLIC  __Vectors_End
+        PUBLIC  __Vectors_Size
+
+        DATA
+__Vectors
+        DCD     0x20010000
+        DCD     Reset_Handler
+        DCD     NMI_Handler
+        DCD     HardFault_Handler
+        DCD     0
+        DCD     0
+        DCD     0
+        DCD     0
+        DCD     0
+        DCD     0
+        DCD     0
+        DCD     SVC_Handler
+        DCD     DebugMon_Handler
+        DCD     0
+        DCD     PendSV_Handler
+        DCD     SysTick_Handler
+
+; External Interrupts
+    DCD    APP_CPU_APP_IRQ_CTIIRQ0_INT_IRQHandler
+    DCD    APP_CPU_APP_IRQ_CTIIRQ1_INT_IRQHandler
+    DCD    APP_CPU_APP_IRQ_I2C1_INT_IRQHandler
+    DCD    APP_CPU_APP_IRQ_I2C2_INT_IRQHandler
+    DCD    APP_CPU_APP_IRQ_I2C3_INT_IRQHandler
+    DCD    APP_CPU_APP_IRQ_I2S_INT_IRQHandler
+    DCD    APP_CPU_APP_IRQ_UART1_INT_IRQHandler
+    DCD    APP_CPU_APP_IRQ_UART2_INT_IRQHandler
+    DCD    APP_CPU_APP_IRQ_SPI1_INT_IRQHandler
+    DCD    APP_CPU_APP_IRQ_SPI2_INT_IRQHandler
+    DCD    APP_CPU_APP_IRQ_TIMER1_INT_IRQHandler
+    DCD    APP_CPU_APP_IRQ_TIMER2_INT_IRQHandler
+    DCD    APP_CPU_APP_IRQ_MDM_WDG_INT_IRQHandler
+    DCD    APP_CPU_APP_IRQ_PHY_WDG_INT_IRQHandler
+    DCD    APP_CPU_APP_IRQ_RF_WDG_INT_IRQHandler
+    DCD    APP_CPU_APP_IRQ_SYSCTRL_ERR_INT_IRQHandler
+    DCD    APP_CPU_APP_IRQ_SYSCTRL_INT_IRQHandler
+    DCD    APP_CPU_APP_IRQ_DMAC_ERR_INT_IRQHandler
+    DCD    APP_CPU_APP_IRQ_DMAC_TC_INT_IRQHandler
+    DCD    APP_CPU_APP_IRQ_DMAC_COMB_INT_IRQHandler
+    DCD    APP_CPU_APP_IRQ_SDIO_INT_IRQHandler
+    DCD    APP_CPU_APP_IRQ_OSPI_INT_IRQHandler
+    DCD    APP_CPU_APP_IRQ_PSRAM_INT_IRQHandler
+    DCD    APP_CPU_APP_IRQ_CRYPTO_INT_IRQHandler
+    DCD    APP_CPU_APP_IRQ_DVS_GLB_INT_IRQHandler
+    DCD    APP_CPU_APP_IRQ_DVS_CORE_INT_IRQHandler
+    DCD    APP_CPU_APP_IRQ_USB_INT_IRQHandler
+    DCD    APP_CPU_APP_IRQ_USB_DMA_INT_IRQHandler
+    DCD    APP_CPU_APP_IRQ_PIO_1_INT_IRQHandler
+    DCD    APP_CPU_APP_IRQ_PIO_2_INT_IRQHandler
+    DCD    APP_CPU_APP_IRQ_PIO_WAKEUP_INT_IRQHandler
+    DCD    APP_CPU_APP_IRQ_PWRCTRL_ERR_INT_IRQHandler
+    DCD    APP_CPU_APP_IRQ_PWRCTRL_INT_IRQHandler
+    DCD    APP_CPU_APP_IRQ_BB_IPC_MBX_TX0_IRQHandler
+    DCD    APP_CPU_APP_IRQ_BB_IPC_MBX_TX1_IRQHandler
+    DCD    APP_CPU_APP_IRQ_BB_IPC_MBX_TX2_IRQHandler
+    DCD    APP_CPU_APP_IRQ_BB_IPC_MBX_RX0_IRQHandler
+    DCD    APP_CPU_APP_IRQ_BB_IPC_MBX_RX1_IRQHandler
+    DCD    APP_CPU_APP_IRQ_BB_IPC_MBX_RX2_IRQHandler
+    DCD    APP_CPU_APP_IRQ_GNSS_TIM_IRQHandler
+    DCD    APP_CPU_APP_IRQ_OTP_FAULT_IRQHandler
+    DCD    APP_CPU_APP_IRQ_ONFI_CAL_IRQHandler
+    DCD    APP_CPU_APP_IRQ_PWRCTRL_WAKEUP_IRQHandler
+    DCD    APP_CPU_APP_IRQ_ETR_LIMITER_THRESHOLD_IRQHandler
+    DCD    APP_CPU_APP_IRQ_USB_WAKEUP_INT_IRQHandler
+    DCD    APP_CPU_APP_IRQ_AC_PWR_ALERT_IRQHandler
+
+__Vectors_End
+
+__Vectors_Size                      EQU   __Vectors_End - __Vectors
+
+; Default handlers.
+        THUMB
+
+        PUBWEAK Reset_Handler
+        SECTION .text:CODE:NOROOT(2)
+Reset_Handler
+        LDR     R0, =SystemInit
+        BLX     R0
+        LDR     R0, =__iar_program_start
+        BX      R0
+
+        ; Dummy exception handlers
+        PUBWEAK NMI_Handler
+        SECTION .text:CODE:NOROOT(1)
+NMI_Handler
+        B .
+        PUBWEAK HardFault_Handler
+        SECTION .text:CODE:NOROOT(1)
+HardFault_Handler
+        B .
+        PUBWEAK SVC_Handler
+        SECTION .text:CODE:NOROOT(1)
+SVC_Handler
+        B .
+        PUBWEAK DebugMon_Handler
+        SECTION .text:CODE:NOROOT(1)
+DebugMon_Handler
+        B .
+        PUBWEAK PendSV_Handler
+        SECTION .text:CODE:NOROOT(1)
+PendSV_Handler
+        B .
+        PUBWEAK SysTick_Handler
+        SECTION .text:CODE:NOROOT(1)
+SysTick_Handler
+        B .
+
+       ; Dummy interrupt handlers
+        PUBWEAK  APP_CPU_APP_IRQ_CTIIRQ0_INT_IRQHandler
+        SECTION .text:CODE:NOROOT(1)
+APP_CPU_APP_IRQ_CTIIRQ0_INT_IRQHandler
+        B .
+        PUBWEAK  APP_CPU_APP_IRQ_CTIIRQ1_INT_IRQHandler
+        SECTION .text:CODE:NOROOT(1)
+APP_CPU_APP_IRQ_CTIIRQ1_INT_IRQHandler
+        B .
+        PUBWEAK  APP_CPU_APP_IRQ_I2C1_INT_IRQHandler
+        SECTION .text:CODE:NOROOT(1)
+APP_CPU_APP_IRQ_I2C1_INT_IRQHandler
+        B .
+        PUBWEAK  APP_CPU_APP_IRQ_I2C2_INT_IRQHandler
+        SECTION .text:CODE:NOROOT(1)
+APP_CPU_APP_IRQ_I2C2_INT_IRQHandler
+        B .
+        PUBWEAK  APP_CPU_APP_IRQ_I2C3_INT_IRQHandler
+        SECTION .text:CODE:NOROOT(1)
+APP_CPU_APP_IRQ_I2C3_INT_IRQHandler
+        B .
+        PUBWEAK  APP_CPU_APP_IRQ_I2S_INT_IRQHandler
+        SECTION .text:CODE:NOROOT(1)
+APP_CPU_APP_IRQ_I2S_INT_IRQHandler
+        B .
+        PUBWEAK  APP_CPU_APP_IRQ_UART1_INT_IRQHandler
+        SECTION .text:CODE:NOROOT(1)
+APP_CPU_APP_IRQ_UART1_INT_IRQHandler
+        B .
+        PUBWEAK  APP_CPU_APP_IRQ_UART2_INT_IRQHandler
+        SECTION .text:CODE:NOROOT(1)
+APP_CPU_APP_IRQ_UART2_INT_IRQHandler
+        B .
+        PUBWEAK  APP_CPU_APP_IRQ_SPI1_INT_IRQHandler
+        SECTION .text:CODE:NOROOT(1)
+APP_CPU_APP_IRQ_SPI1_INT_IRQHandler
+        B .
+        PUBWEAK  APP_CPU_APP_IRQ_SPI2_INT_IRQHandler
+        SECTION .text:CODE:NOROOT(1)
+APP_CPU_APP_IRQ_SPI2_INT_IRQHandler
+        B .
+        PUBWEAK  APP_CPU_APP_IRQ_TIMER1_INT_IRQHandler
+        SECTION .text:CODE:NOROOT(1)
+APP_CPU_APP_IRQ_TIMER1_INT_IRQHandler
+        B .
+        PUBWEAK  APP_CPU_APP_IRQ_TIMER2_INT_IRQHandler
+        SECTION .text:CODE:NOROOT(1)
+APP_CPU_APP_IRQ_TIMER2_INT_IRQHandler
+        B .
+        PUBWEAK  APP_CPU_APP_IRQ_MDM_WDG_INT_IRQHandler
+        SECTION .text:CODE:NOROOT(1)
+APP_CPU_APP_IRQ_MDM_WDG_INT_IRQHandler
+        B .
+        PUBWEAK  APP_CPU_APP_IRQ_PHY_WDG_INT_IRQHandler
+        SECTION .text:CODE:NOROOT(1)
+APP_CPU_APP_IRQ_PHY_WDG_INT_IRQHandler
+        B .
+        PUBWEAK  APP_CPU_APP_IRQ_RF_WDG_INT_IRQHandler
+        SECTION .text:CODE:NOROOT(1)
+APP_CPU_APP_IRQ_RF_WDG_INT_IRQHandler
+        B .
+        PUBWEAK  APP_CPU_APP_IRQ_SYSCTRL_ERR_INT_IRQHandler
+        SECTION .text:CODE:NOROOT(1)
+APP_CPU_APP_IRQ_SYSCTRL_ERR_INT_IRQHandler
+        B .
+        PUBWEAK  APP_CPU_APP_IRQ_SYSCTRL_INT_IRQHandler
+        SECTION .text:CODE:NOROOT(1)
+APP_CPU_APP_IRQ_SYSCTRL_INT_IRQHandler
+        B .
+        PUBWEAK  APP_CPU_APP_IRQ_DMAC_ERR_INT_IRQHandler
+        SECTION .text:CODE:NOROOT(1)
+APP_CPU_APP_IRQ_DMAC_ERR_INT_IRQHandler
+        B.
+        PUBWEAK  APP_CPU_APP_IRQ_DMAC_TC_INT_IRQHandler
+        SECTION .text:CODE:NOROOT(1)
+APP_CPU_APP_IRQ_DMAC_TC_INT_IRQHandler
+        B.
+        PUBWEAK  APP_CPU_APP_IRQ_DMAC_COMB_INT_IRQHandler
+        SECTION .text:CODE:NOROOT(1)
+APP_CPU_APP_IRQ_DMAC_COMB_INT_IRQHandler
+        B.
+        PUBWEAK  APP_CPU_APP_IRQ_SDIO_INT_IRQHandler
+        SECTION .text:CODE:NOROOT(1)
+APP_CPU_APP_IRQ_SDIO_INT_IRQHandler
+        B.
+        PUBWEAK  APP_CPU_APP_IRQ_OSPI_INT_IRQHandler
+        SECTION .text:CODE:NOROOT(1)
+APP_CPU_APP_IRQ_OSPI_INT_IRQHandler
+        B.
+        PUBWEAK  APP_CPU_APP_IRQ_PSRAM_INT_IRQHandler
+        SECTION .text:CODE:NOROOT(1)
+APP_CPU_APP_IRQ_PSRAM_INT_IRQHandler
+        B.
+        PUBWEAK  APP_CPU_APP_IRQ_CRYPTO_INT_IRQHandler
+        SECTION .text:CODE:NOROOT(1)
+APP_CPU_APP_IRQ_CRYPTO_INT_IRQHandler
+        B.
+        PUBWEAK  APP_CPU_APP_IRQ_DVS_GLB_INT_IRQHandler
+        SECTION .text:CODE:NOROOT(1)
+APP_CPU_APP_IRQ_DVS_GLB_INT_IRQHandler
+        B.
+        PUBWEAK  APP_CPU_APP_IRQ_DVS_CORE_INT_IRQHandler
+        SECTION .text:CODE:NOROOT(1)
+APP_CPU_APP_IRQ_DVS_CORE_INT_IRQHandler
+        B.
+        PUBWEAK  APP_CPU_APP_IRQ_USB_INT_IRQHandler
+        SECTION .text:CODE:NOROOT(1)
+APP_CPU_APP_IRQ_USB_INT_IRQHandler
+        B.
+        PUBWEAK  APP_CPU_APP_IRQ_USB_DMA_INT_IRQHandler
+        SECTION .text:CODE:NOROOT(1)
+APP_CPU_APP_IRQ_USB_DMA_INT_IRQHandler
+        B.
+        PUBWEAK  APP_CPU_APP_IRQ_PIO_1_INT_IRQHandler
+        SECTION .text:CODE:NOROOT(1)
+APP_CPU_APP_IRQ_PIO_1_INT_IRQHandler
+        B.
+        PUBWEAK  APP_CPU_APP_IRQ_PIO_2_INT_IRQHandler
+        SECTION .text:CODE:NOROOT(1)
+APP_CPU_APP_IRQ_PIO_2_INT_IRQHandler
+        B.
+        PUBWEAK  APP_CPU_APP_IRQ_PIO_WAKEUP_INT_IRQHandler
+        SECTION .text:CODE:NOROOT(1)
+APP_CPU_APP_IRQ_PIO_WAKEUP_INT_IRQHandler
+        B.
+        PUBWEAK  APP_CPU_APP_IRQ_PWRCTRL_ERR_INT_IRQHandler
+        SECTION .text:CODE:NOROOT(1)
+APP_CPU_APP_IRQ_PWRCTRL_ERR_INT_IRQHandler
+        B.
+        PUBWEAK  APP_CPU_APP_IRQ_PWRCTRL_INT_IRQHandler
+        SECTION .text:CODE:NOROOT(1)
+APP_CPU_APP_IRQ_PWRCTRL_INT_IRQHandler
+        B.
+        PUBWEAK  APP_CPU_APP_IRQ_BB_IPC_MBX_TX0_IRQHandler
+        SECTION .text:CODE:NOROOT(1)
+APP_CPU_APP_IRQ_BB_IPC_MBX_TX0_IRQHandler
+        B.
+        PUBWEAK  APP_CPU_APP_IRQ_BB_IPC_MBX_TX1_IRQHandler
+        SECTION .text:CODE:NOROOT(1)
+APP_CPU_APP_IRQ_BB_IPC_MBX_TX1_IRQHandler
+        B.
+        PUBWEAK  APP_CPU_APP_IRQ_BB_IPC_MBX_TX2_IRQHandler
+        SECTION .text:CODE:NOROOT(1)
+APP_CPU_APP_IRQ_BB_IPC_MBX_TX2_IRQHandler
+        B.
+        PUBWEAK  APP_CPU_APP_IRQ_BB_IPC_MBX_RX0_IRQHandler
+        SECTION .text:CODE:NOROOT(1)
+APP_CPU_APP_IRQ_BB_IPC_MBX_RX0_IRQHandler
+        B.
+        PUBWEAK  APP_CPU_APP_IRQ_BB_IPC_MBX_RX1_IRQHandler
+        SECTION .text:CODE:NOROOT(1)
+APP_CPU_APP_IRQ_BB_IPC_MBX_RX1_IRQHandler
+        B.
+        PUBWEAK  APP_CPU_APP_IRQ_BB_IPC_MBX_RX2_IRQHandler
+        SECTION .text:CODE:NOROOT(1)
+APP_CPU_APP_IRQ_BB_IPC_MBX_RX2_IRQHandler
+        B.
+        PUBWEAK  APP_CPU_APP_IRQ_GNSS_TIM_IRQHandler
+        SECTION .text:CODE:NOROOT(1)
+APP_CPU_APP_IRQ_GNSS_TIM_IRQHandler
+        B.
+        PUBWEAK  APP_CPU_APP_IRQ_OTP_FAULT_IRQHandler
+        SECTION .text:CODE:NOROOT(1)
+APP_CPU_APP_IRQ_OTP_FAULT_IRQHandler
+        B.
+        PUBWEAK  APP_CPU_APP_IRQ_ONFI_CAL_IRQHandler
+        SECTION .text:CODE:NOROOT(1)
+APP_CPU_APP_IRQ_ONFI_CAL_IRQHandler
+        B.
+        PUBWEAK  APP_CPU_APP_IRQ_PWRCTRL_WAKEUP_IRQHandler
+        SECTION .text:CODE:NOROOT(1)
+APP_CPU_APP_IRQ_PWRCTRL_WAKEUP_IRQHandler
+        B.
+        PUBWEAK  APP_CPU_APP_IRQ_ETR_LIMITER_THRESHOLD_IRQHandler
+        SECTION .text:CODE:NOROOT(1)
+APP_CPU_APP_IRQ_ETR_LIMITER_THRESHOLD_IRQHandler
+        B.
+        PUBWEAK  APP_CPU_APP_IRQ_USB_WAKEUP_INT_IRQHandler
+        SECTION .text:CODE:NOROOT(1)
+APP_CPU_APP_IRQ_USB_WAKEUP_INT_IRQHandler
+        B.
+        PUBWEAK  APP_CPU_APP_IRQ_AC_PWR_ALERT_IRQHandler
+        SECTION .text:CODE:NOROOT(1)
+APP_CPU_APP_IRQ_AC_PWR_ALERT_IRQHandler
+        B.
+        END


### PR DESCRIPTION
### Description
Adding IAR toolchain support for R5303 KM target by adding startup and linker script

-> Added linker script with CODE_RO, DATA(RW), .intvec and CSTACK sections in memory region
-> Good example: tested led and serial tests with it. but in serial not getting echo back.


### Pull request type

<!-- 
    Required
    Please tick one of the following types 
-->

- [ ] Fix
- [ ] Refactor
- [ ] New target
- [X] Feature
- [ ] Breaking change
