### PR TITLE
psram config

### DIFF
--- a/targets/TARGET_ublox/TARGET_R5030/device/TOOLCHAIN_ARM_STD/r5030.sct
+++ b/targets/TARGET_ublox/TARGET_R5030/device/TOOLCHAIN_ARM_STD/r5030.sct
@@ -24,7 +24,7 @@
 
 ; R5030_APPS_PROC: 64 KB FLASH (0x10000) + 64 KB SRAM (0x10000)
 LR_IROM1 0x00000000 0x10000  {    ; load region size_region
-  ER_IROM1 0x00000000 0x00010000  {  ; load address = execution address
+  ER_IROM1 0x00000000 0x10000  {  ; load address = execution address
    *.o (RESET, +First)
    *(InRoot$$Sections)
    .ANY (+RO)
@@ -35,4 +35,3 @@ LR_IROM1 0x00000000 0x10000  {    ; load region size_region
    .ANY (+RW +ZI)
   }
 }
-

--- a/targets/TARGET_ublox/TARGET_R5030/device/TOOLCHAIN_ARM_STD/startup_KM_app.s
+++ b/targets/TARGET_ublox/TARGET_R5030/device/TOOLCHAIN_ARM_STD/startup_KM_app.s
@@ -38,6 +38,7 @@
 ;//-------- <<< Use Configuration Wizard in Context Menu >>> ------------------
 ;*/
 
+//#define PSRAM_CONFIG_BINARY //this macro needs to be defined when compiling the psram_config binary. For other applications, comment it out.
 
 ; <h> Stack Configuration
 ;   <o> Stack Size (in Bytes) <0x0-0xFFFFFFFF:8>
@@ -144,7 +145,7 @@ __Vectors_End
 __Vectors_Size  EQU     __Vectors_End - __Vectors
 
                 AREA    |.text|, CODE, READONLY
-
+				ENTRY
 
 ; Reset Handler
 
@@ -155,7 +156,15 @@ Reset_Handler   PROC
                 EXPORT  Reset_Handler             [WEAK]
                 IMPORT  SystemInit
                 IMPORT  __main
-                LDR     R0, =SystemInit
+#ifdef PSRAM_CONFIG_BINARY
+                LDR 	R1, = 0x4960002C ; address width register of PSRAM. It is 0 when PSRAM in uninitialized
+                LDR 	R2,[R1] ; read value of address width register
+                CMP 	R2, #0 ; check if it is zero
+                BEQ		Init_PSRAM ; if zero, proceed executing the program. This program initailizes the PSRAM and in the end performs a core reset
+				B       . ; if non-zero, it means PSRAM is already initialized so loop here and do nothing. At this stage, we can load the second program
+Init_PSRAM
+#endif
+      			LDR     R0, =SystemInit
                 BLX     R0
                 LDR     R0, =__main
                 BX      R0

--- a/targets/TARGET_ublox/TARGET_R5030/device/TOOLCHAIN_ARM_STD/startup_KM_app.s
+++ b/targets/TARGET_ublox/TARGET_R5030/device/TOOLCHAIN_ARM_STD/startup_KM_app.s
@@ -161,7 +161,7 @@ Reset_Handler   PROC
                 LDR 	R2,[R1] ; read value of address width register
                 CMP 	R2, #0 ; check if it is zero
                 BEQ		Init_PSRAM ; if zero, proceed executing the program. This program initailizes the PSRAM and in the end performs a core reset
-				B       . ; if non-zero, it means PSRAM is already initialized so loop here and do nothing. At this stage, we can load the second program
+                B       . ; if non-zero, it means PSRAM is already initialized so loop here and do nothing. At this stage, we can load the second program
 Init_PSRAM
 #endif
       			LDR     R0, =SystemInit

--- a/targets/TARGET_ublox/TARGET_R5030/device/TOOLCHAIN_ARM_STD/startup_KM_app.s
+++ b/targets/TARGET_ublox/TARGET_R5030/device/TOOLCHAIN_ARM_STD/startup_KM_app.s
@@ -145,7 +145,7 @@ __Vectors_End
 __Vectors_Size  EQU     __Vectors_End - __Vectors
 
                 AREA    |.text|, CODE, READONLY
-				ENTRY
+                ENTRY
 
 ; Reset Handler
 

--- a/targets/TARGET_ublox/TARGET_R5030/device/TOOLCHAIN_GCC_ARM/startup_KM_app.S
+++ b/targets/TARGET_ublox/TARGET_R5030/device/TOOLCHAIN_GCC_ARM/startup_KM_app.S
@@ -285,7 +285,7 @@ Reset_Handler:
     ldr 	R2,[R1] // read value of address width register
     cmp 	R2, #0 // check if it is zero
     beq		Init_PSRAM // if zero, proceed executing the program. This program initailizes the PSRAM and in the end performs a core reset
-	b       . // if non-zero, it means PSRAM is already initialized so loop here and do nothing. At this stage, we can load the second program
+    b       . // if non-zero, it means PSRAM is already initialized so loop here and do nothing. At this stage, we can load the second program
 Init_PSRAM:
 #endif
 

--- a/targets/TARGET_ublox/TARGET_R5030/device/TOOLCHAIN_GCC_ARM/startup_KM_app.S
+++ b/targets/TARGET_ublox/TARGET_R5030/device/TOOLCHAIN_GCC_ARM/startup_KM_app.S
@@ -34,6 +34,8 @@
    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
    POSSIBILITY OF SUCH DAMAGE.
    ---------------------------------------------------------------------------*/
+
+//#define PSRAM_CONFIG_BINARY //this macro needs to be defined when compiling the psram_config binary. For other applications, comment it out.
 #define __STARTUP_CLEAR_BSS
 
     .syntax    unified
@@ -277,6 +279,15 @@ Reset_Handler:
     bgt    .L_loop3
 .L_loop3_done:
 #endif /* __STARTUP_CLEAR_BSS_MULTIPLE || __STARTUP_CLEAR_BSS */
+
+#ifdef PSRAM_CONFIG_BINARY
+    ldr 	R1, = 0x4960002C // address width register of PSRAM. It is 0 when PSRAM in uninitialized
+    ldr 	R2,[R1] // read value of address width register
+    cmp 	R2, #0 // check if it is zero
+    beq		Init_PSRAM // if zero, proceed executing the program. This program initailizes the PSRAM and in the end performs a core reset
+	b       . // if non-zero, it means PSRAM is already initialized so loop here and do nothing. At this stage, we can load the second program
+Init_PSRAM:
+#endif
 
 #ifndef __NO_SYSTEM_INIT
     bl    SystemInit

--- a/targets/TARGET_ublox/TARGET_R5030/device/cmsis_nvic.h
+++ b/targets/TARGET_ublox/TARGET_R5030/device/cmsis_nvic.h
@@ -26,7 +26,7 @@
 #define NVIC_NUM_VECTORS      (16 + 46)   // CORE + MCU Peripherals
 #define NVIC_USER_IRQ_OFFSET  16
 #define NVIC_RAM_VECTOR_ADDRESS   (0x20000000)  // Location of vectors in RAM
-#define NVIC_FLASH_VECTOR_ADDRESS (0x00000000)  // Initial vector position in flash
+#define NVIC_FLASH_VECTOR_ADDRESS (0x00000000)  // Initial vector position in flash. Make sure to change it to correct position as defined in scatter file
 
 #include "cmsis.h"
 

--- a/targets/TARGET_ublox/TARGET_R5030/device/system_KM_app.c
+++ b/targets/TARGET_ublox/TARGET_R5030/device/system_KM_app.c
@@ -95,8 +95,9 @@ void SystemInit (void)
 /* ToDo: add code to initialize the system
          do not use global variables because this function is called before
          reaching pre-main. RW section maybe overwritten afterwards.          */
-  SystemCoreClock = __SYSTEM_CLOCK;
-  ExternalClock = __EXTERNAL_CLOCK;
+    SCB->VTOR = (uint32_t)NVIC_FLASH_VECTOR_ADDRESS; //VTOR is required to be changed if code is placed at address other than 0x00000000 
+    SystemCoreClock = __SYSTEM_CLOCK;
+    ExternalClock = __EXTERNAL_CLOCK;
 }
 
 // Initializes the System Timer and its interrupt, and starts the System Tick Timer.

--- a/tools/profiles/debug.json
+++ b/tools/profiles/debug.json
@@ -34,7 +34,7 @@
         "asm": [],
         "c": ["--md", "--no_depend_system_headers", "--c99", "-D__ASSERT_MSG"],
         "cxx": ["--cpp", "--no_rtti", "--no_vla"],
-        "ld": ["--show_full_path"]
+        "ld": ["--show_full_path", "--entry=Reset_Handler"]
     },
     "uARM": {
         "common": ["-c", "--gnu", "-Otime", "--split_sections",

--- a/tools/profiles/develop.json
+++ b/tools/profiles/develop.json
@@ -31,7 +31,7 @@
         "asm": [],
         "c": ["--md", "--no_depend_system_headers", "--c99", "-D__ASSERT_MSG"],
         "cxx": ["--cpp", "--no_rtti", "--no_vla"],
-        "ld": ["--show_full_path"]
+        "ld": ["--show_full_path", "--entry=Reset_Handler"]
     },
     "uARM": {
         "common": ["-c", "--gnu", "-Otime", "--split_sections",

--- a/tools/profiles/release.json
+++ b/tools/profiles/release.json
@@ -31,7 +31,7 @@
         "asm": [],
         "c": ["--md", "--no_depend_system_headers", "--c99", "-D__ASSERT_MSG"],
         "cxx": ["--cpp", "--no_rtti", "--no_vla"],
-        "ld": ["--show_full_path"]
+        "ld": ["--show_full_path", "--entry=Reset_Handler"]
     },
     "uARM": {
         "common": ["-c", "--gnu", "-Ospace", "--split_sections",


### PR DESCRIPTION
### Description

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/guidelines.html#workflow (Pull request template)
--> 

- To compile binary that sets up the PSRAM, get main file from [here ](https://github.com/wajahat-ublox/KM_psram_config) and uncomment the PSRAM_CONFIG_BINARY macro in startup file. Once this binary is run on FPGA, disconnect and load second binary that uses the PSRAM. Tested with GCC, ARM and IAR. 

- Make sure to update NVIC_FLASH_VECTOR_ADDRESS if code is to be placed in PSRAM as VTOR is initially set at this address.

- The linker flag --entry in mbed profiles will be removed later once we move to real chip


### Pull request type

<!-- 
    Required
    Please tick one of the following types 
-->

- [ ] Fix
- [ ] Refactor
- [ ] New target
- [ ] Feature
- [ ] Breaking change
