### PR TITLE
Reduced clock speeds as FPGA is working at 26/5 MHz

### DIFF
--- a/drivers/SPI.cpp
+++ b/drivers/SPI.cpp
@@ -37,7 +37,7 @@ SPI::SPI(PinName mosi, PinName miso, PinName sclk, PinName ssel) :
 #endif
         _bits(8),
         _mode(0),
-        _hz(1000000),
+        _hz(500000),
         _write_fill(SPI_FILL_CHAR) {
     // No lock needed in the constructor
 

--- a/targets/TARGET_ublox/TARGET_R5030/device/system_KM_app.c
+++ b/targets/TARGET_ublox/TARGET_R5030/device/system_KM_app.c
@@ -54,7 +54,7 @@
 //#define __XTAL            (300000000UL)    /* Oscillator frequency             */
 //#define __SYS_OSC_CLK     (    ___HSI)    /* Main oscillator frequency        */
 
-#define __SYSTEM_CLOCK    (26000000UL)
+#define __SYSTEM_CLOCK    (5200000UL)
 #define __EXTERNAL_CLOCK    (1000000UL)
 
 

--- a/targets/TARGET_ublox/TARGET_R5030/spi_api.c
+++ b/targets/TARGET_ublox/TARGET_R5030/spi_api.c
@@ -25,7 +25,7 @@
 #define SPI1_BASE    app_ss_app_spi1
 #define SPI2_BASE    app_ss_app_spi2
 
-#define PerCLK   26000000UL // Peripheral clock
+#define PerCLK   5200000UL // Peripheral clock
 #define PCLK    PerCLK // APB clock
 
 


### PR DESCRIPTION
### Description
FPGA is running on reduced clock rates.
<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/guidelines.html#workflow (Pull request template)
-->


### Pull request type

<!-- 
    Required
    Please tick one of the following types 
-->

- [ ] Fix
- [ ] Refactor
- [ ] New target
- [ ] Feature
- [ ] Breaking change
